### PR TITLE
Added the possibility to split values into separate meta fields 

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Use the field type of `date_range` when initializing your CMB2 Field.
  		'desc'       => __( 'field description (optional)', 'cmb2' ),
  		'id'         => $prefix . 'date_range',
  		'type'       => 'date_range',
+ 		// 'split_values' => true, // Save start date and end date as two separate fields
  	) );
  ```
 

--- a/wds-cmb2-date-range-field.php
+++ b/wds-cmb2-date-range-field.php
@@ -77,8 +77,8 @@ class WDS_CMB2_Date_Range_Field {
 
 		add_action( 'init', array( $this, 'init' ) );
 		add_action( 'cmb2_render_date_range', array( $this, 'render' ), 10, 5 );
-		add_filter( 'cmb2_sanitize_date_range', array( $this, 'sanitize' ), 10, 4 );
-		add_action( 'cmb2_save_field', array( $this, 'save_field' ), 10, 4 );
+		add_filter( 'cmb2_sanitize_date_range', array( $this, 'sanitize' ), 10, 2 );
+		add_action( 'cmb2_save_field', array( $this, 'save_split_fields' ), 10, 4 );
 	}
 
 	/**
@@ -141,7 +141,7 @@ class WDS_CMB2_Date_Range_Field {
 	 *
 	 * @return array|mixed An array of the dates.
 	 */
-	function sanitize( $override_value, $value, $object_id, $field_args ) {
+	function sanitize( $override_value, $value ) {
 
 		$value = json_decode( $value, true );
 		if ( is_array( $value ) ) {
@@ -154,7 +154,7 @@ class WDS_CMB2_Date_Range_Field {
 
 	}
 
-	function save_field( $field_id, $updated, $action, $cmb2_field ) {
+	function save_split_fields( $field_id, $updated, $action, $cmb2_field ) {
 
 		if ( ! $updated || $action == 'repeatable' ) {
 			return;

--- a/wds-cmb2-date-range-field.php
+++ b/wds-cmb2-date-range-field.php
@@ -78,6 +78,7 @@ class WDS_CMB2_Date_Range_Field {
 		add_action( 'init', array( $this, 'init' ) );
 		add_action( 'cmb2_render_date_range', array( $this, 'render' ), 10, 5 );
 		add_filter( 'cmb2_sanitize_date_range', array( $this, 'sanitize' ), 10, 4 );
+		add_action( 'cmb2_save_field', array( $this, 'save_field' ), 10, 4 );
 	}
 
 	/**
@@ -149,17 +150,35 @@ class WDS_CMB2_Date_Range_Field {
 			sanitize_text_field( $value );
 		}
 
-		if ( isset( $field_args['split_values'] ) && $field_args['split_values'] ) {
-			if ( ! empty( $value['start'] ) ) {
-				update_post_meta( $object_id, $field_args['id'] . '_start', $value['start'] );
-			}
-			if ( ! empty( $value['end'] ) ) {
-				update_post_meta( $object_id, $field_args['id'] . '_end', $value['end'] );
-			}
-		}
-
 		return $value;
 
+	}
+
+	function save_field( $field_id, $updated, $action, $cmb2_field ) {
+
+		if ( ! $updated || $action == 'repeatable' ) {
+			return;
+		}
+
+		$object_type  = $cmb2_field->object_type;
+		$object_id    = $cmb2_field->object_id;
+		$value        = $cmb2_field->value;
+		$split_values = $cmb2_field->args( 'split_values' );
+
+		$start_date_key = $field_id . '_start';
+		$end_date_key   = $field_id . '_end';
+
+		if ( $action == 'removed' ) {
+
+			delete_metadata( $object_type, $object_id, $start_date_key );
+			delete_metadata( $object_type, $object_id, $end_date_key );
+
+		} elseif ( $split_values ) {
+
+			update_metadata( $object_type, $object_id, $start_date_key, $value['start'] );
+			update_metadata( $object_type, $object_id, $end_date_key, $value['end'] );
+
+		}
 	}
 }
 

--- a/wds-cmb2-date-range-field.php
+++ b/wds-cmb2-date-range-field.php
@@ -120,7 +120,7 @@ class WDS_CMB2_Date_Range_Field {
 		}
 
 		// CMB2_Types::parse_args allows arbitrary attributes to be added
-		$a = $field_type->parse_args( array(), 'input', array(
+		$a = $field_type->parse_args( 'input', array(), array(
 			'type'  => 'text',
 			'class' => 'date-range button-secondary',
 			'name'  => $field_type->_name(),

--- a/wds-cmb2-date-range-field.php
+++ b/wds-cmb2-date-range-field.php
@@ -154,6 +154,14 @@ class WDS_CMB2_Date_Range_Field {
 
 	}
 
+	/**
+	 * Save the start date and end date into separate fields
+	 *
+	 * @param string            $field_id The current field id paramater.
+	 * @param bool              $updated  Whether the metadata update action occurred.
+	 * @param string            $action   Action performed. Could be "repeatable", "updated", or "removed".
+	 * @param CMB2_Field object $field    This field object
+	 */
 	function save_split_fields( $field_id, $updated, $action, $cmb2_field ) {
 
 		if ( ! $updated || $action == 'repeatable' ) {

--- a/wds-cmb2-date-range-field.php
+++ b/wds-cmb2-date-range-field.php
@@ -77,7 +77,7 @@ class WDS_CMB2_Date_Range_Field {
 
 		add_action( 'init', array( $this, 'init' ) );
 		add_action( 'cmb2_render_date_range', array( $this, 'render' ), 10, 5 );
-		add_filter( 'cmb2_sanitize_date_range', array( $this, 'sanitize' ), 10, 2 );
+		add_filter( 'cmb2_sanitize_date_range', array( $this, 'sanitize' ), 10, 4 );
 	}
 
 	/**
@@ -140,13 +140,22 @@ class WDS_CMB2_Date_Range_Field {
 	 *
 	 * @return array|mixed An array of the dates.
 	 */
-	function sanitize( $override_value, $value ) {
+	function sanitize( $override_value, $value, $object_id, $field_args ) {
 
 		$value = json_decode( $value, true );
 		if ( is_array( $value ) ) {
 			$value = array_map( 'sanitize_text_field', $value );
 		} else {
 			sanitize_text_field( $value );
+		}
+
+		if ( isset( $field_args['split_values'] ) && $field_args['split_values'] ) {
+			if ( ! empty( $value['start'] ) ) {
+				update_post_meta( $object_id, $field_args['id'] . '_start', $value['start'] );
+			}
+			if ( ! empty( $value['end'] ) ) {
+				update_post_meta( $object_id, $field_args['id'] . '_end', $value['end'] );
+			}
 		}
 
 		return $value;


### PR DESCRIPTION
By splitting the values and saving them as separate meta values, the start date and end date can be used to sort and filter the posts in WP_Query.
